### PR TITLE
chore: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Derive version string
         id: bin_version
         run: echo "bin_version=$(./.version.sh)" >> "$GITHUB_OUTPUT"
@@ -76,12 +76,12 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -89,9 +89,9 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: actionlint
-        uses: raven-actions/actionlint@v2.1.2
+        uses: raven-actions/actionlint@v2
 
   binaries:
     name: Binaries & Debian Packages
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -111,7 +111,7 @@ jobs:
         run: go version
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.267.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
           bundler-cache: true
@@ -130,7 +130,7 @@ jobs:
           cp ./*.deb ./gh-release/
           find . -name '${{ needs.meta.outputs.bin_name }}-*' -executable -type f -maxdepth 1 -print0 | xargs -0 -I {} tar --transform='flags=r;s|.*|${{ needs.meta.outputs.bin_name }}|' -czvf ./gh-release/{}.tar.gz {}
       - name: Upload binaries & packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out/gh-release/*
@@ -146,7 +146,7 @@ jobs:
       contents: write
     steps:
       - name: Download binaries & packages
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out
@@ -154,7 +154,7 @@ jobs:
         working-directory: out
         run: ls -R
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2.4.1
+        uses: softprops/action-gh-release@v3
         with:
           files: out/${{ needs.meta.outputs.bin_name }}-*
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
@@ -170,9 +170,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Update running major/minor version tags
-        uses: sersoft-gmbh/running-release-tags-action@v3.0.0
+        uses: sersoft-gmbh/running-release-tags-action@v4
         with:
           fail-on-non-semver-tag: true
           create-release: false
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binaries & packages
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release to ${{ needs.meta.outputs.brewtap_owner }}/${{ needs.meta.outputs.brewtap_name }} tap
-        uses: Justintime50/homebrew-releaser@v2.2.0
+        uses: Justintime50/homebrew-releaser@v3
         with:
           homebrew_owner: ${{ needs.meta.outputs.brewtap_owner }}
           homebrew_tap: homebrew-${{ needs.meta.outputs.brewtap_name }}


### PR DESCRIPTION
## Summary

Updates all GitHub Actions in `.github/workflows/main.yml` to their latest major versions.

## Version Changes

| Action | Old | New | Type |
|--------|-----|-----|------|
| `actions/checkout` | v5 | v6 | Major bump |
| `golangci/golangci-lint-action` | v8 | v9 | Major bump |
| `raven-actions/actionlint` | v2.0.1 | v2 | Floating major tag |
| `ruby/setup-ruby` | v1.267.0 | v1 | Floating major tag |
| `actions/upload-artifact` | v5 | v7 | Major bump (2 majors) |
| `actions/download-artifact` | v6 | v8 | Major bump (2 majors) |
| `softprops/action-gh-release` | v2.4.1 | v3 | Major bump |
| `sersoft-gmbh/running-release-tags-action` | v3.0.0 | v4 | Major bump |
| `Justintime50/homebrew-releaser` | v2.2.0 | v3 | Major bump |

**No changes needed:** `actions/setup-go@v6`, `tailscale/github-action@v4`, `niniyas/ntfy-action@V1.0.5` — already on latest major versions.

## Breaking Changes to Be Aware Of

### Node 24 runtime requirement (affects most updates)
Multiple actions now run on Node 24 instead of Node 20. **GitHub-hosted runners are already compatible.** Self-hosted runners need Actions Runner v2.327.1+ (or v2.329.0+ for `actions/checkout@v6`).

### `actions/checkout@v6`
- Persist-credentials now stored under `$RUNNER_TEMP` instead of local git config. Requires runner v2.329.0+ for Docker container action scenarios.

### `actions/download-artifact@v8`
- **Hash mismatches now error by default** (previously just warned). Configurable via `digest-mismatch` input.
- No longer auto-unzips non-zipped downloads (compatible with `upload-artifact@v7` direct uploads). New `skip-decompress` option available.

### `actions/upload-artifact@v7`
- Migrated to ESM module. Should be transparent to callers.
- Adds `archive: false` option for direct (unzipped) single-file uploads.

### `softprops/action-gh-release@v3`
- Moved runtime from Node 20 to Node 24. If Node 20 compatibility is needed, stay on v2.6.2.

### `sersoft-gmbh/running-release-tags-action@v4`
- Updated to Node 24. Needs runner v2.328.0+.

### `Justintime50/homebrew-releaser@v3`
- Docker image completely overhauled: pre-built image (faster, ~500mb vs ~1.5gb). Uses stable Debian instead of Brew image. Homebrew v5. Python v3.14. `formula_folder` is now optional (defaults to `Formula`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline tools to their latest versions to maintain compatibility and security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->